### PR TITLE
fix passing self to metamethods, and add t=self arg syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,13 @@ You can specify coma separated arguments that will be passed to any function Dev
 be in the form of a `string`, `number`, `nil`, `boolean`, and/or `table`.
 
 - **Note**, _to pass a value with type `table` you have to specify prefix `t=`_.
+- **Note**, _to pass the parent table, specify `t=self`_.
+- **Note**, _DevTool will automatically try passing `self` as first arg, if the function throws an error_.
 
 Example passing arguments to a function `SomeFunction`:
 
 - FN Call Args: `t=MyObject, 12, a12` becomes `SomeFunction(_G.MyObject, 12, a12)`
+- FN Call Args: `t=self, 12, a12` becomes `SomeObject:SomeFunction(12, a12)`
 - FN Call Args: `t=MyObject.Frame1.Frame2` becomes `SomeFunction(_G.MyObject.Frame1.Frame2)`
 
 ### Chat commands:

--- a/Utilities/Utils.lua
+++ b/Utilities/Utils.lua
@@ -266,18 +266,18 @@ function DevTool.TryCallFunctionWithArgs(fn, args)
 end
 
 function DevTool.IsMetaTableNode(info)
-	return info.name == "$metatable" or info.name == "$metatable.__index"
+	return info.name == "$metatable" or info.name == "$metatable.__index" or (info.name == "__index" and info.parent and info.parent.name == "$metatable")
 end
 
 function DevTool.GetParentTable(info)
 	local parent = info.parent
-	if parent and parent.value == _G then
-		-- this fn is in global namespace so no parent
+	if parent and (parent.value == _G or parent == DevTool.list) then
+		-- this fn is in global namespace, or has no parent
 		parent = nil
 	end
 
 	if parent then
-		if DevTool.IsMetaTableNode(parent) then
+		while DevTool.IsMetaTableNode(parent) do
 			-- metatable has real object 1 level higher
 			parent = parent.parent
 		end


### PR DESCRIPTION
devtool will already automatically pass the parent to a function, if the function returns an error (though that's not helpful for functions that simply return nil, when no valid parent is passed)
but this was broken when using __index metamethods that are tables, and only worked for __index metamethods that are functions

in addition, I always felt like it'd be nice to be able to explicitly pass the `self` argument, so I also added `t=self` as an argument

comparing to DevTool.list, is needed to fix an error with GetParentTable returning DevTool.list, for functions that are added directly, e.g. through `DevTool:AddData(someFunc)`