### PR TITLE
Feature: Show and print variable taint info

### DIFF
--- a/XML/MainFrame.xml
+++ b/XML/MainFrame.xml
@@ -273,11 +273,18 @@ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI
                     <Anchor point="RIGHT" relativeTo="DevToolFrameColumnResizeButton" relativePoint="LEFT" x="10"/>
                 </Anchors>
             </Button>
+            <!--COLUMN 4-->
+            <Button text="Test Text" name="$parentTaintColumn" inherits="DevToolColumnTemplate" parentKey="taintButton">
+                <Size x="50"/>
+                <Anchors>
+                    <Anchor point="RIGHT"/>
+                </Anchors>
+            </Button>
             <!--COLUMN 3-->
             <Button text="Test Text" name="$parentValueColumn" inherits="DevToolColumnTemplate"
                     parentKey="valueButton">
                 <Anchors>
-                    <Anchor point="RIGHT"/>
+                    <Anchor point="RIGHT" relativeTo="$parentTaintColumn" relativePoint="LEFT"/>
                     <Anchor point="LEFT" relativeTo="$parentNameColumn" relativePoint="RIGHT"/>
                 </Anchors>
             </Button>


### PR DESCRIPTION
Getting information about taint can be tricky as a dev. I think DevTool could help here, by providing a way to drill down on Blizz variables and check which parts have been tainted.

So this PR adds:

- A small 4th column to the table that shows if a variable is tainted. It' empty if not, and shows "Tainted" if it is.
- A 2nd line to the right-click print that outputs the name of the addon tainting the variable.

It works on child variables of added table data, as well as top level data that has a value in the global table with the same name.