### PR TITLE
Add handling of secret values introduced in 12.0.0

### DIFF
--- a/DevTool.lua
+++ b/DevTool.lua
@@ -765,16 +765,17 @@ function DevTool:ProcessCallFunctionData(ok, info, parent, args, results)
 	-- for example 1, 2, nil, 4 should return only this 4 values nothing more, nothing less.
 	local found = false
 	for i = 10, 1, -1 do
-		if results[i] ~= nil then
+        local result = DevTool.normalizeSecretValue(results[i])
+		if result ~= nil then
 			found = true
 		end
 
 		if found or i == 1 then
 			-- if found some return or if return is nil
-			table.insert(elements, self:NewElement(results[i], string.format("  return: %d", i), indentation))
+			table.insert(elements, self:NewElement(result, string.format("  return: %d", i), indentation))
 
-			returnFormattedStr = string.format(" %s (%s)%s", tostring(results[i]),
-					self.colors.lightblue:WrapTextInColorCode(type(results[i])), returnFormattedStr)
+			returnFormattedStr = string.format(" %s (%s)%s", tostring(result),
+					self.colors.lightblue:WrapTextInColorCode(type(result)), returnFormattedStr)
 		end
 	end
 

--- a/DevTool.lua
+++ b/DevTool.lua
@@ -235,6 +235,16 @@ function DevTool:AddData(data, dataName)
 		return
 	end
 
+    if issecrettable(data) then
+		self:Print("Error: The data being added is a secret table. Aborting.")
+		return
+	end
+
+    if issecretvalue(data) then
+		self:Print("Error: The data being added is a secret value. Aborting.")
+		return
+	end
+
 	if not dataName then
 		dataName = tostring(data)
 	end

--- a/DevTool.toc
+++ b/DevTool.toc
@@ -1,4 +1,4 @@
-## Interface: 11507, 50500, 110200
+## Interface: 11507, 50500, 110200, 120000
 ## Title: DevTool
 ## Notes: A multipurpose tool to assist with addon development
 ## IconTexture: Interface\Icons\inv_misc_gear_08

--- a/Utilities/Utils.lua
+++ b/Utilities/Utils.lua
@@ -10,6 +10,16 @@ local DevTool = addonTable.DevTool
 --- UTILS
 -----------------------------------------------------------------------------------------------
 
+function DevTool.normalizeSecretValue(value)
+    if issecrettable(value) then
+        return "<SECRET TABLE>"
+    end
+    if issecretvalue(value) then
+        return "<SECRET VALUE>"
+    end
+    return value
+end
+
 --- Math
 
 function DevTool.round(num, idp)
@@ -174,6 +184,8 @@ function DevTool.ToUIString(value, name, withoutLineBrakes)
 		result = tostring(value)
 	end
 
+    result = DevTool.normalizeSecretValue(result)
+
 	if withoutLineBrakes then
 		result = string.gsub(string.gsub(tostring(result), "|n", ""), "\n", "")
 	end
@@ -188,8 +200,9 @@ function DevTool.GetObjectInfoFromWoWAPI(helperText, value)
 	-- try to get frame name
 	if ok then
 		local concat = function(str, before, after)
-			before = before or ""
-			after = after or ""
+			before = DevTool.normalizeSecretValue(before) or ""
+			after = DevTool.normalizeSecretValue(after) or ""
+            str = DevTool.normalizeSecretValue(str)
 			if str then
 				return resultStr .. " " .. before .. str .. after
 			end
@@ -210,6 +223,8 @@ function DevTool.GetObjectInfoFromWoWAPI(helperText, value)
 					tostring(DevTool.round(width)) .. ", " ..
 					tostring(DevTool.round(height)) .. "]")
 		end
+
+        name = DevTool.normalizeSecretValue(name)
 
 		if helperText ~= name then
 			resultStr = concat(name, DevTool.colors.gray:WrapTextInColorCode("<"), DevTool.colors.gray:WrapTextInColorCode(">"))


### PR DESCRIPTION
- Adds a `DevTool.normalizeSecretValue` helper that helps prevent trying to do operations/comparisons on secret values by converting them to `<SECRET VALUE>` strings. This also makes sure that we show when a value is secret, which is very handy to know.
- Adds secret value check to `DevTool:AddData` to prevent adding any secret values

Potentially some more places that needs patching, but this has been working for me.