### PR TITLE
Improve secret handling, and fix function call returns being broken

### DIFF
--- a/DevTool.lua
+++ b/DevTool.lua
@@ -772,7 +772,7 @@ function DevTool:ProcessCallFunctionData(ok, info, parent, args, results)
 
 		if found or i == 1 then
 			-- if found some return or if return is nil
-			table.insert(elements, self:NewElement(result, string.format("  return: %d", i), indentation))
+			elements[i] = self:NewElement(result, string.format("  return: %d", i), indentation)
 
 			returnFormattedStr = string.format(" %s (%s)%s", DevTool.secretToString(result),
 					self.colors.lightblue:WrapTextInColorCode(type(result)), returnFormattedStr)
@@ -791,8 +791,8 @@ function DevTool:ProcessCallFunctionData(ok, info, parent, args, results)
 
 	self:UpdateMainTableUI()
 
-	--print info to chat
-	self:Print(stateStr(ok) .. " " .. fnNameWithArgs .. self.colors.gray:WrapTextInColorCode(" returns:") .. returnFormattedStr)
+	--print info to chat (not using self:Print since AceConsole:Print currently doesn't support secrets)
+	print("|cff33ff99DevTool|r:", stateStr(ok), fnNameWithArgs, self.colors.gray:WrapTextInColorCode("returns:"), returnFormattedStr)
 end
 
 -----------------------------------------------------------------------------------------------

--- a/DevTool.lua
+++ b/DevTool.lua
@@ -529,7 +529,7 @@ function DevTool:UIUpdateMainTableButton(element, info, id)
 
 	element.nameButton:SetPoint("LEFT", element.rowNumberButton, "RIGHT", 10 * info.indentation - 10, 0)
 
-	element.valueButton:SetText(DevTool.ToUIString(info.value, info.name, true))
+	element.valueButton:GetFontString():SetText(DevTool.ToUIString(info.value, info.name, true))
 	element.nameButton:SetText(tostring(info.name))
 	element.rowNumberButton:SetText(tostring(id))
 
@@ -765,7 +765,7 @@ function DevTool:ProcessCallFunctionData(ok, info, parent, args, results)
 	-- for example 1, 2, nil, 4 should return only this 4 values nothing more, nothing less.
 	local found = false
 	for i = 10, 1, -1 do
-		local result = DevTool.secretToString(results[i])
+		local result = results[i]
 		if result ~= nil then
 			found = true
 		end
@@ -774,7 +774,7 @@ function DevTool:ProcessCallFunctionData(ok, info, parent, args, results)
 			-- if found some return or if return is nil
 			table.insert(elements, self:NewElement(result, string.format("  return: %d", i), indentation))
 
-			returnFormattedStr = string.format(" %s (%s)%s", tostring(result),
+			returnFormattedStr = string.format(" %s (%s)%s", DevTool.secretToString(result),
 					self.colors.lightblue:WrapTextInColorCode(type(result)), returnFormattedStr)
 		end
 	end

--- a/Utilities/Utils.lua
+++ b/Utilities/Utils.lua
@@ -165,17 +165,16 @@ end
 
 function DevTool.ToUIString(value, name, withoutLineBrakes)
 	local result
-	value = DevTool.secretToString(value)
 	local valueType = type(value)
 
 	if valueType == "table" then
-		result = DevTool.GetObjectInfoFromWoWAPI(name, value) or tostring(value)
+		result = DevTool.GetObjectInfoFromWoWAPI(name, value) or DevTool.secretToString(value)
 		result = "(" .. DevTool.CountElements(value) .. ") " .. result
 	else
-		result = tostring(value)
+		result = DevTool.secretToString(value)
 	end
 
-	if withoutLineBrakes then
+	if withoutLineBrakes and not DevTool.isSecret(result) then
 		result = string.gsub(string.gsub(tostring(result), "|n", ""), "\n", "")
 	end
 
@@ -247,7 +246,7 @@ function DevTool.GetObjectInfoFromWoWAPI(helperText, value)
 
 		resultStr = concat(texture)
 		resultStr = concat(text, "'", "'")
-		resultStr = concat(tostring(value))
+		resultStr = concat(DevTool.secretToString(value))
 	end
 
 	return resultStr
@@ -323,9 +322,9 @@ function DevTool.isSecret(value)
 	return false
 end
 
-function DevTool.secretToString(value)
+function DevTool.secretToString(value, withoutPrefix)
 	if DevTool.isSecret(value) then
-		return string.format("<SECRET %s>", type(value))
+		return string.format(withoutPrefix and "%s" or "<SECRET> %s", value)
 	end
 	return tostring(value)
 end


### PR DESCRIPTION
<img width="1179" height="488" alt="image" src="https://github.com/user-attachments/assets/36ad0d65-529e-406c-a819-3804e3010379" />

- return values are now ordered 1 -> n rather than n -> 1
- return values properly detect nils again (so no longer shows 10 nil returns)
- secret values are displayed (concatenating secrets has been allowed by Blizzard quite early in the alpha)